### PR TITLE
Minor issues discovered when installing on Mason

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -186,6 +186,7 @@ tar -xzf GapFiller_v1-10_linux-x86_64.tar.gz
 # We need to apply a small patch to the program so that it will work
 # with modern versions of Perl.
 cd GapFiller_v1-10_linux-x86_64
+dos2unix GapFiller.pl
 cp GapFiller.pl GapFiller.plORIG
 patch GapFiller.plORIG -i $TRegGA_DIR/patches/gapfiller.patch -o GapFiller.pl
 chmod 755 GapFiller.pl
@@ -297,6 +298,10 @@ patch libs/gage.pyORIG -i $TRegGA_DIR/patches/quast.patch -o libs/gage.py
 python quast.py --gage --test
 python metaquast.py --test
 ```
+
+### R
+
+For installation instructions, see https://www.r-project.org.
 
 ### Samtools
 

--- a/TRegGA.config.example
+++ b/TRegGA.config.example
@@ -1,3 +1,4 @@
+TRegGA_DIR=/home/TRegGA
 KMERGENIE_DIR=/home/TRegGA/local/src/kmergenie-1.6950
 TRIMMOMATIC=/home/TRegGA/local/src/Trimmomatic-0.33/trimmomatic-0.33.jar
 ADAPTORS=/home/TRegGA/local/src/Trimmomatic-0.33/adapters

--- a/check-data.sh
+++ b/check-data.sh
@@ -10,5 +10,5 @@ shasum -c checksums.sha
 cd -
 
 cd targets/
-shasum -c checksums.embl
+shasum -c checksums.sha
 cd -

--- a/check-prereqs.sh
+++ b/check-prereqs.sh
@@ -13,7 +13,7 @@ done
 
 for program in AlignGraph Eval-AlignGraph art act dnaplotter bowtie bowtie2 \
                bwa entret fastqc GapFiller.pl gth gt ngsutils samtools \
-               SOAPdenovo-63mer SOAPdenovo-127mer fastq-dump; do
+               SOAPdenovo-63mer SOAPdenovo-127mer fastq-dump Rscript; do
     echo -n "[TRegGA] Third-party program $program ... "
     which $program > /dev/null 2>&1
     returnstatus=$?


### PR DESCRIPTION
- Apparently the `GapFiller.pl` file has DOS line endings.
  The `patch` command on modern versions of Fedora handles this fine, but not on older versions of Red Hat (aka Mason).
  Calling `dos2unix` before applying the patch does the trick.
- KmerGenie relies on `Rscript` (part of the R distribution), but since this is installed so ubiquitously I missed the dependency until I tested on Mason.
  Added to the list of prerequisites and to the `check-prereqs.sh` script.
- Fixed erroneous checksum filename.
- Re-introduced the `TRegGA_DIR` variable back into the `TRegGA.config.example` file.
