### PR TITLE
Fixed xgetreads...

### DIFF
--- a/reads/xgetreads
+++ b/reads/xgetreads
@@ -31,10 +31,10 @@ echo "# Cultivar (DNA_VARNAME) name:	$cultivar"
 echo ""
 echo "#Description (from file rice_line_metadata_20140521.tsv):"
 echo ""
-egrep "	$cultivar	" *tsv
+egrep "$cultivar	" *tsv
 echo ""
 
-sample=`egrep "	$cultivar	" *tsv | cut -d"	" -f1`
+sample=`egrep "$cultivar	" *tsv | cut -d"	" -f1`
 echo "Sample (sample_alias) name:	$sample"
 
 echo ""


### PR DESCRIPTION
...so that grep would recognize cultivar accessions at the beginning of lines in rice_line_metadata_20140521.tsv
Previously the grep pattern was " $cultivar ", ignoring matches at the beginning of each line, which is where the accessions usually occur.